### PR TITLE
Hide prints

### DIFF
--- a/Scripts/gcat_random_rays.py
+++ b/Scripts/gcat_random_rays.py
@@ -11,14 +11,20 @@ from scipy.interpolate import interp1d
 from astropy.table import Table
 import time
 
+from yt.utilities.logger import set_log_level as set_log_level_yt
+from yt.config import ytcfg
+
 from utils import (
     fit_lines,
     load_snapshot,
-    run_galaxy_snapshot,
+    run_galaxy_snapshot_fast,
     run_simple_ray,
     run_simple_ray_fast
 )
 
+# set yt log level
+set_log_level_yt("error")
+ytcfg.update({"yt": {"suppress_stream_logging": True}})
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/Scripts/gcat_random_rays.py
+++ b/Scripts/gcat_random_rays.py
@@ -17,7 +17,7 @@ from yt.config import ytcfg
 from utils import (
     fit_lines,
     load_snapshot,
-    run_galaxy_snapshot_fast,
+    run_galaxy_snapshot,
     run_simple_ray,
     run_simple_ray_fast
 )

--- a/Scripts/gcat_random_rays.py
+++ b/Scripts/gcat_random_rays.py
@@ -22,10 +22,6 @@ from utils import (
     run_simple_ray_fast
 )
 
-# set yt log level
-set_log_level_yt("error")
-ytcfg.update({"yt": {"suppress_stream_logging": True}})
-
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -167,6 +163,12 @@ def main(args):
     if args.num_processors == 0:
         args.num_processors = (multiprocessing.cpu_count() // 2)
     print("Running with nproc = ", args.num_processors)
+
+    # set yt log level
+    if not args.verbose:
+        set_log_level_yt("error")
+        ytcfg.update({"yt": {"suppress_stream_logging": True}})
+
     t0 = time.time()
 
     #################################
@@ -428,6 +430,10 @@ if __name__ == "__main__":
                         type=int,
                         default=458467463,
                         help='Seed for the random number generator')
+    parser.add_argument("--verbose",
+                        action="store_true",
+                        help="""If passed, then print all the info from yt and
+                            trident""")
     parser.add_argument("--z-dist",
                         type=str,
                         default=f"{THIS_DIR}/../Data/dr16_dla_ndz.txt",

--- a/Scripts/gcat_random_rays.py
+++ b/Scripts/gcat_random_rays.py
@@ -207,7 +207,7 @@ def main(args):
             ]).transpose()
 
         t1 = time.time()
-        print(f"INFO: Catalogue loaded. Eelapsed time: {(t1-t0)/60.0} minutes")
+        print(f"INFO: Catalogue loaded. Elapsed time: {(t1-t0)/60.0} minutes")
 
         # run the missing skewers in parallel
         print("Running missing skewers")
@@ -231,7 +231,7 @@ def main(args):
                 pool.starmap(run_simple_ray_fast, arguments)
 
         t2 = time.time()
-        print(f"INFO: Run {len(not_run_catalogue)} skewers. Eelapsed time: {(t2-t1)/60.0} minutes")
+        print(f"INFO: Run {len(not_run_catalogue)} skewers. lapsed time: {(t2-t1)/60.0} minutes")
 
     ####################################
     # new run:                         #
@@ -318,7 +318,7 @@ def main(args):
         catalogue.write(f"{args.output_dir}/{args.catalogue_file}")
 
         t1 = time.time()
-        print(f"INFO: Catalogue created. Eelapsed time: {(t1-t0)/60.0} minutes")
+        print(f"INFO: Catalogue created. Elapsed time: {(t1-t0)/60.0} minutes")
 
         # run the skewers in parallel
         print("Running skewers")
@@ -342,7 +342,7 @@ def main(args):
 
 
         t2 = time.time()
-        print(f"INFO: Run {len(catalogue)} skewers. Eelapsed time: {(t2-t1)/60.0} minutes")
+        print(f"INFO: Run {len(catalogue)} skewers. Elapsed time: {(t2-t1)/60.0} minutes")
 
     print("Fitting profiles")
     t3 = time.time()


### PR DESCRIPTION
This PR adds the option to hide the messages from yt and trident. These are printed in the error channel.
Running 4 spectra on 1 cpu without the messages takes 1.44 minutes. With the messages, it takes 1.45 minutes