### PR TITLE
Fix parallel

### DIFF
--- a/Scripts/utils.py
+++ b/Scripts/utils.py
@@ -1173,7 +1173,7 @@ def run_simple_ray_fast(ds,
         redshift=z,
         lines='all',
         fields=['density', 'temperature', 'metallicity'],
-        data_filename=f"{base_name}_ray.h5"
+        data_filename=f"{output_dir}{base_name}_ray.h5"
         )
     spec_gen = trident.SpectrumGenerator(
         lambda_min= 3000,

--- a/Scripts/utils.py
+++ b/Scripts/utils.py
@@ -1173,6 +1173,7 @@ def run_simple_ray_fast(ds,
         redshift=z,
         lines='all',
         fields=['density', 'temperature', 'metallicity'],
+        data_filename=f"{base_name}_ray.h5"
         )
     spec_gen = trident.SpectrumGenerator(
         lambda_min= 3000,


### PR DESCRIPTION
The function `create_simple_ray` apparently needs to save the file before returning. Since we were not specifying a file, then it was always saving them with the default name, hence the racing problems. 